### PR TITLE
Add notifyOnBuildFinished for end-of-build summary notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,31 @@ slack {
 
 ## Configuration
 
-| Property        | Type           | Default                                            | Description                                         |
-| --------------- | -------------- | -------------------------------------------------- | --------------------------------------------------- |
-| `webhookUrl`    | `String`       | _required_                                         | Slack incoming-webhook URL.                         |
-| `shouldMonitor` | `List<String>` | `[]`                                               | Task names whose completion triggers a notification. |
-| `username`     | `String`       | `"Gradle"`                                         | Display name of the bot in Slack.                   |
-| `iconUrl`      | `String`       | Gradlephant PNG                                    | Avatar URL for the bot.                             |
-| `introText`    | `String`       | `"Your Gradle Build is Complete:"`                 | Leading text above the attachment.                  |
+| Property                | Type           | Default                                | Description                                                                                       |
+| ----------------------- | -------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `webhookUrl`            | `String`       | _required_                             | Slack incoming-webhook URL.                                                                       |
+| `shouldMonitor`         | `List<String>` | `[]`                                   | Task names whose completion triggers a notification (per-task mode).                              |
+| `notifyOnBuildFinished` | `Boolean`      | `false`                                | When `true`, send a single summary notification after the whole build finishes instead of per task. |
+| `username`              | `String`       | `"Gradle"`                             | Display name of the bot in Slack.                                                                 |
+| `iconUrl`               | `String`       | Gradlephant PNG                        | Avatar URL for the bot.                                                                           |
+| `introText`             | `String`       | `"Your Gradle Build is Complete:"`     | Leading text above the attachment.                                                                |
+
+### Per-build vs. per-task notifications
+
+By default the plugin sends a message each time a task listed in `shouldMonitor`
+completes. If you'd rather have a single summary at the end of the whole build —
+with an overall Success/Failure status and task counts — set
+`notifyOnBuildFinished = true`:
+
+```kotlin
+slack {
+    webhookUrl.set(providers.environmentVariable("SLACK_WEBHOOK_URL"))
+    notifyOnBuildFinished = true
+}
+```
+
+In this mode `shouldMonitor` is ignored — every task the build runs contributes
+to the summary.
 
 ### Keeping the webhook URL out of source control
 

--- a/src/main/kotlin/com/alexleventer/slack/SlackBuildService.kt
+++ b/src/main/kotlin/com/alexleventer/slack/SlackBuildService.kt
@@ -10,8 +10,11 @@ import org.gradle.tooling.events.OperationCompletionListener
 import org.gradle.tooling.events.task.TaskFailureResult
 import org.gradle.tooling.events.task.TaskFinishEvent
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicInteger
 
-abstract class SlackBuildService : BuildService<SlackBuildService.Params>, OperationCompletionListener {
+abstract class SlackBuildService :
+    BuildService<SlackBuildService.Params>, OperationCompletionListener, AutoCloseable {
 
     interface Params : BuildServiceParameters {
         val webhookUrl: Property<String>
@@ -19,22 +22,55 @@ abstract class SlackBuildService : BuildService<SlackBuildService.Params>, Opera
         val iconUrl: Property<String>
         val introText: Property<String>
         val shouldMonitor: ListProperty<String>
+        val notifyOnBuildFinished: Property<Boolean>
         val projectDir: Property<String>
     }
 
     private val api: SlackApi by lazy { SlackApi(parameters.webhookUrl.get()) }
     private val gitUtil by lazy { GitUtil(File(parameters.projectDir.get())) }
 
+    private val anyFailure = AtomicBoolean(false)
+    private val taskCount = AtomicInteger(0)
+    private val failedCount = AtomicInteger(0)
+
     override fun onFinish(event: FinishEvent) {
         if (event !is TaskFinishEvent) return
         val taskName = event.descriptor.taskPath.substringAfterLast(":")
+        val success = event.result !is TaskFailureResult
+
+        if (parameters.notifyOnBuildFinished.getOrElse(false)) {
+            taskCount.incrementAndGet()
+            if (!success) {
+                anyFailure.set(true)
+                failedCount.incrementAndGet()
+            }
+            return
+        }
+
         if (taskName !in parameters.shouldMonitor.get()) return
         if (parameters.webhookUrl.orNull.isNullOrBlank()) return
 
-        val success = event.result !is TaskFailureResult
-        val message = SlackMessageBuilder(
+        val message = SlackMessageBuilder.forTask(
             taskName = taskName,
             success = success,
+            username = parameters.username.get(),
+            iconUrl = parameters.iconUrl.get(),
+            introText = parameters.introText.get(),
+            git = gitUtil
+        ).build()
+
+        runCatching { api.postMessage(message) }
+    }
+
+    override fun close() {
+        if (!parameters.notifyOnBuildFinished.getOrElse(false)) return
+        if (parameters.webhookUrl.orNull.isNullOrBlank()) return
+        if (taskCount.get() == 0) return
+
+        val message = SlackMessageBuilder.forBuild(
+            success = !anyFailure.get(),
+            totalTasks = taskCount.get(),
+            failedTasks = failedCount.get(),
             username = parameters.username.get(),
             iconUrl = parameters.iconUrl.get(),
             introText = parameters.introText.get(),

--- a/src/main/kotlin/com/alexleventer/slack/SlackExtension.kt
+++ b/src/main/kotlin/com/alexleventer/slack/SlackExtension.kt
@@ -9,12 +9,14 @@ abstract class SlackExtension {
     abstract val iconUrl: Property<String>
     abstract val introText: Property<String>
     abstract val shouldMonitor: ListProperty<String>
+    abstract val notifyOnBuildFinished: Property<Boolean>
 
     init {
         username.convention("Gradle")
         iconUrl.convention(DEFAULT_ICON_URL)
         introText.convention("Your Gradle Build is Complete:")
         shouldMonitor.convention(emptyList())
+        notifyOnBuildFinished.convention(false)
     }
 
     fun shouldMonitor(vararg tasks: String) {

--- a/src/main/kotlin/com/alexleventer/slack/SlackMessageBuilder.kt
+++ b/src/main/kotlin/com/alexleventer/slack/SlackMessageBuilder.kt
@@ -4,9 +4,10 @@ import com.alexleventer.slack.utils.GitUtil
 import com.alexleventer.slack.utils.Json
 import java.time.Instant
 
-open class SlackMessageBuilder(
-    private val taskName: String,
+open class SlackMessageBuilder private constructor(
+    private val title: String,
     private val success: Boolean,
+    private val fields: List<Map<String, Any>>,
     private val username: String,
     private val iconUrl: String,
     private val introText: String,
@@ -16,18 +17,13 @@ open class SlackMessageBuilder(
         val authorEmail = git.lastCommitAuthorEmail().orEmpty()
         val authorAvatar = "https://www.gravatar.com/avatar/${Json.md5(authorEmail.lowercase())}?d=identicon"
 
-        val fields = listOf(
-            mapOf("title" to "Task", "value" to taskName, "short" to true),
-            mapOf("title" to "Status", "value" to if (success) "Success" else "Failure", "short" to true)
-        )
-
         val attachment = mapOf(
             "color" to if (success) "good" else "danger",
             "footer" to "Gradle Build",
             "footer_icon" to iconUrl,
             "author_name" to git.lastCommitAuthorName().orEmpty(),
             "author_icon" to authorAvatar,
-            "title" to git.lastCommitMessage().orEmpty(),
+            "title" to title,
             "ts" to Instant.now().epochSecond,
             "fields" to fields
         )
@@ -41,5 +37,48 @@ open class SlackMessageBuilder(
         )
 
         return Json.encode(payload)
+    }
+
+    companion object {
+        fun forTask(
+            taskName: String,
+            success: Boolean,
+            username: String,
+            iconUrl: String,
+            introText: String,
+            git: GitUtil
+        ) = SlackMessageBuilder(
+            title = git.lastCommitMessage().orEmpty(),
+            success = success,
+            fields = listOf(
+                mapOf("title" to "Task", "value" to taskName, "short" to true),
+                mapOf("title" to "Status", "value" to if (success) "Success" else "Failure", "short" to true)
+            ),
+            username = username,
+            iconUrl = iconUrl,
+            introText = introText,
+            git = git
+        )
+
+        fun forBuild(
+            success: Boolean,
+            totalTasks: Int,
+            failedTasks: Int,
+            username: String,
+            iconUrl: String,
+            introText: String,
+            git: GitUtil
+        ) = SlackMessageBuilder(
+            title = git.lastCommitMessage().orEmpty(),
+            success = success,
+            fields = listOf(
+                mapOf("title" to "Status", "value" to if (success) "Success" else "Failure", "short" to true),
+                mapOf("title" to "Tasks", "value" to "$totalTasks executed, $failedTasks failed", "short" to true)
+            ),
+            username = username,
+            iconUrl = iconUrl,
+            introText = introText,
+            git = git
+        )
     }
 }

--- a/src/main/kotlin/com/alexleventer/slack/SlackPlugin.kt
+++ b/src/main/kotlin/com/alexleventer/slack/SlackPlugin.kt
@@ -21,6 +21,7 @@ abstract class SlackPlugin : Plugin<Project> {
             spec.parameters.iconUrl.set(extension.iconUrl)
             spec.parameters.introText.set(extension.introText)
             spec.parameters.shouldMonitor.set(extension.shouldMonitor)
+            spec.parameters.notifyOnBuildFinished.set(extension.notifyOnBuildFinished)
             spec.parameters.projectDir.set(project.rootDir.absolutePath)
         }
 

--- a/src/main/kotlin/com/alexleventer/slack/utils/GitUtil.kt
+++ b/src/main/kotlin/com/alexleventer/slack/utils/GitUtil.kt
@@ -3,13 +3,13 @@ package com.alexleventer.slack.utils
 import java.io.File
 import java.util.concurrent.TimeUnit
 
-class GitUtil(private val workingDir: File) {
+open class GitUtil(private val workingDir: File) {
 
-    fun lastCommitAuthorName(): String? = run("git", "log", "-1", "--format=%an")
+    open fun lastCommitAuthorName(): String? = run("git", "log", "-1", "--format=%an")
 
-    fun lastCommitAuthorEmail(): String? = run("git", "log", "-1", "--format=%ae")
+    open fun lastCommitAuthorEmail(): String? = run("git", "log", "-1", "--format=%ae")
 
-    fun lastCommitMessage(): String? = run("git", "log", "-1", "--format=%B")
+    open fun lastCommitMessage(): String? = run("git", "log", "-1", "--format=%B")
 
     private fun run(vararg command: String): String? = try {
         val proc = ProcessBuilder(*command)

--- a/src/test/kotlin/com/alexleventer/slack/SlackMessageBuilderTest.kt
+++ b/src/test/kotlin/com/alexleventer/slack/SlackMessageBuilderTest.kt
@@ -1,0 +1,47 @@
+package com.alexleventer.slack
+
+import com.alexleventer.slack.utils.GitUtil
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class SlackMessageBuilderTest {
+
+    private val git = object : GitUtil(File(".")) {
+        override fun lastCommitAuthorName() = "Jane Dev"
+        override fun lastCommitAuthorEmail() = "jane@example.com"
+        override fun lastCommitMessage() = "feat: add widgets"
+    }
+
+    @Test
+    fun `forTask emits task name and status fields`() {
+        val json = SlackMessageBuilder.forTask(
+            taskName = "build",
+            success = true,
+            username = "Gradle",
+            iconUrl = "http://icon",
+            introText = "Done:",
+            git = git
+        ).build()
+
+        assertThat(json).contains("\"title\":\"Task\"", "\"value\":\"build\"")
+        assertThat(json).contains("\"value\":\"Success\"", "\"color\":\"good\"")
+        assertThat(json).contains("\"title\":\"feat: add widgets\"")
+    }
+
+    @Test
+    fun `forBuild emits aggregate counts and failure color`() {
+        val json = SlackMessageBuilder.forBuild(
+            success = false,
+            totalTasks = 12,
+            failedTasks = 3,
+            username = "Gradle",
+            iconUrl = "http://icon",
+            introText = "Build finished:",
+            git = git
+        ).build()
+
+        assertThat(json).contains("\"value\":\"Failure\"", "\"color\":\"danger\"")
+        assertThat(json).contains("\"title\":\"Tasks\"", "\"value\":\"12 executed, 3 failed\"")
+    }
+}

--- a/src/test/kotlin/com/alexleventer/slack/SlackPluginTest.kt
+++ b/src/test/kotlin/com/alexleventer/slack/SlackPluginTest.kt
@@ -25,6 +25,7 @@ class SlackPluginTest {
         assertThat(ext.introText.get()).isEqualTo("Your Gradle Build is Complete:")
         assertThat(ext.shouldMonitor.get()).isEmpty()
         assertThat(ext.iconUrl.get()).contains("gradlephant.png")
+        assertThat(ext.notifyOnBuildFinished.get()).isFalse()
     }
 
     @Test


### PR DESCRIPTION
Closes [#2](https://github.com/alexleventer/gradle-slack-plugin/issues/2).

## Summary

Adds a `notifyOnBuildFinished` option that sends a single summary Slack message when the whole build finishes, instead of one notification per monitored task. Requested by @ysb33r back in 2019.

```kotlin
slack {
    webhookUrl.set(providers.environmentVariable("SLACK_WEBHOOK_URL"))
    notifyOnBuildFinished = true
}
```

The summary attachment shows overall **Success/Failure** plus a count of tasks executed and failed. In this mode `shouldMonitor` is ignored — every task the build runs contributes to the aggregate status.

## Implementation

- `SlackBuildService` now implements `AutoCloseable`. Task outcomes are aggregated in `onFinish` via thread-safe counters, then flushed from `close()` — which Gradle calls exactly once when the build ends.
- Split `SlackMessageBuilder` into two factory methods (`forTask` / `forBuild`) so each notification mode owns its own set of attachment fields without branching in the core builder.
- `SlackExtension` gains `notifyOnBuildFinished: Property<Boolean>` with a `false` convention — behavior is unchanged unless you opt in.

## Test plan

- [x] `./gradlew build` — 7 tests pass
- [x] New `SlackMessageBuilderTest` covers both `forTask` and `forBuild` factories (field names, values, success/failure color)
- [x] `SlackPluginTest` extended to assert `notifyOnBuildFinished` default is `false`
- [ ] Smoke test against a real Slack webhook with `notifyOnBuildFinished = true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)